### PR TITLE
Added functionality for 'e' and 'pi' as input arguments

### DIFF
--- a/scicalc
+++ b/scicalc
@@ -62,6 +62,7 @@ if __name__ == "__main__":
 	try:
 		op = sys.argv[1]
 		my_args = []
+		#allowing for e an pi as inputs
 		for arg in sys.argv[2:]:
 			if arg == 'e':
 				my_args.append(2.718281828459)

--- a/scicalc
+++ b/scicalc
@@ -61,7 +61,16 @@ if __name__ == "__main__":
 	#
 	try:
 		op = sys.argv[1]
-		args = [ float(arg) for arg in sys.argv[2:] ]
+		my_args = []
+		for arg in sys.argv[2:]:
+			if arg == 'e':
+				my_args.append(2.718281828459)
+			elif arg == 'pi':
+				my_args.append(3.14159265)
+			else:
+				my_args.append(arg)
+
+		args = [ float(arg) for arg in my_args ]
 	except IndexError:
 		die_with_usage("Insufficient number of arguments.")
 	except ValueError as e:


### PR DESCRIPTION
Hi, with this change both 'e' and 'pi' will work as inputs and can be used in _any_ function. 